### PR TITLE
Add an encoder to `run`

### DIFF
--- a/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialService.java
+++ b/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialService.java
@@ -434,7 +434,7 @@ public class RCTBluetoothSerialService {
                 try {
                     // Read from the InputStream
                     bytes = mmInStream.read(buffer);
-                    String data = new String(buffer, 0, bytes);
+                    String data = new String(buffer, 0, bytes, "ISO-8859-1");
 
                     // Send the new data String to the UI Activity
                     mModule.receiveMessage(RCTBluetoothSerialModule.MESSAGE_READ, data);


### PR DESCRIPTION
If there is not an encoder here, the `buffer` bytes which should have
been bigger than '0x79' will be set to '0xFFFD'