### PR TITLE
Fix write() in RCTBluetoothSerialService.java (Android)

### DIFF
--- a/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialService.java
+++ b/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialService.java
@@ -91,7 +91,7 @@ class RCTBluetoothSerialService {
 
         // Synchronize a copy of the ConnectedThread
         synchronized (this) {
-            if (isConnected()) return;
+            if (!isConnected()) return;
             r = mConnectedThread;
         }
 


### PR DESCRIPTION
Fix writeToDevice() on Android does not work.
write() method in RCTBluetoothSerialService class should return when a state is not connected.