### PR TITLE
[iOS] Support RN 0.4x as well as older <= 0.3x

### DIFF
--- a/ios/RCTBluetoothSerial/RCTBluetoothSerial.h
+++ b/ios/RCTBluetoothSerial/RCTBluetoothSerial.h
@@ -6,8 +6,15 @@
 //  Copyright © 2016 Jakub Martyčák. All rights reserved.
 //
 
+#if __has_include(<React/RCTBridgeModule.h>)
+// React Native >= 0.40
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
+#else
+// React Native <= 0.39
+#import "RCTBridgeModule.h"
+#import "RCTEventDispatcher.h"
+#endif
 
 //#import "RCTEventEmitter.h" Wasnt working properly yet, events were fired but listeneres not called
 #import "BLE.h"


### PR DESCRIPTION
Conditionally import the React Native headers by detecting the header files available.

See #48 