### PR TITLE
support RN 0.47

### DIFF
--- a/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
+++ b/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
@@ -20,7 +20,8 @@ public class RCTBluetoothSerialPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated RN 0.47
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/ios/RCTBluetoothSerial/RCTBluetoothSerial.m
+++ b/ios/RCTBluetoothSerial/RCTBluetoothSerial.m
@@ -23,6 +23,11 @@
 
 RCT_EXPORT_MODULE();
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 @synthesize bridge = _bridge;
 
 - (instancetype)init {


### PR DESCRIPTION
[React Native 0.47.0](https://github.com/facebook/react-native/releases/tag/v0.47.0)
Breaking changes:
Android
Remove unused createJSModules calls

