### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Officialy this library supports React Native >= 0.25, it may run on older versio
     ```
 4. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
     ```
-    compile project(':react-native-bluetooth-serial')
+    implementation project(':react-native-bluetooth-serial')
     ```
 
 ## Example


### PR DESCRIPTION
Using compile command for manual installation gives 'Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api' ' error. Replacing compile with implementation solves the issue.