### PR TITLE
Update RTCBluetoothSerialPackage remove @Override

### DIFF
--- a/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
+++ b/android/src/main/java/com/rusel/RCTBluetoothSerial/RCTBluetoothSerialPackage.java
@@ -20,7 +20,6 @@ public class RCTBluetoothSerialPackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
@rusel1989 Please update the file RTCBluetoothSerialPackage to remove override from createJSModules function because it is not implemented in ReactPackage, reference: https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.java